### PR TITLE
Add missing GitHub Skills activity (#6)

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,20 @@
+I enjoyed this interactive tutorial, "Integrate MCP with Github Copilot" and think you might too.
+
+Here's what you can learn:
+
++ Model Context Protocol (MCP) Server Configuration: Setting up and connecting the GitHub MCP server to Copilot
++ Agent Mode with MCP: Using natural language to interact with external services through MCP tools
++ GitHub Repository Research: Searching for and analyzing similar projects using MCP capabilities
++ Issue Management & Implementation: Triaging, creating, and managing GitHub issues through Copilot, then having Copilot solve issues for you
+
+One highlight that made me smile:
+
++ copilot looked and 16 issues and prioritised top 3 with justification. Top issue was that "Github Skills" was from the Mergington High School CCA missing (ha! this AI system has business context! 😂 ). If I'd skimmed 16 issue titles, I may have missed that.
+
+One drawback that broke the tut flow:
+
+- observed some requests to Claude Sonnet 4.5 taking 90 seconds to receive a response. By comparison, gpt-4o-mini responded in 500ms.
+
+Try it yourself -> https://lnkd.in/gM3ZTU58
+
+#GitHubSkills hashtag#OpenSource hashtag#GitHubLearn hashtag#mcp hashtag#copilot hashtag#claude hashtag#gpt

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills as part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Resolves #6 

Added the missing "GitHub Skills" activity to the school activities list, as announced by the principal.

**Changes:**
- Added "GitHub Skills" entry to the `activities` dictionary in `src/app.py`.
- Included description, schedule (Mondays and Wednesdays, 3:30 PM - 5:00 PM), and max participants (25).